### PR TITLE
refactoring to split cli and library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.18",
  "libc",
  "winapi 0.3.9",
 ]
@@ -64,7 +64,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "clap",
+ "clap 2.33.3",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -152,10 +152,47 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+dependencies = [
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim 0.10.0",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -272,6 +309,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,7 +411,7 @@ dependencies = [
 name = "hdrfix"
 version = "1.0.3"
 dependencies = [
- "clap",
+ "clap 4.1.6",
  "glam",
  "half",
  "image",
@@ -369,6 +427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +440,12 @@ checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
 
 [[package]]
 name = "humantime"
@@ -423,12 +493,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -494,9 +586,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -519,6 +611,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -728,7 +826,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.18",
  "libc",
 ]
 
@@ -740,6 +838,18 @@ checksum = "467e40ada50d13bab19019e3707862b5076ca15841f31ee1474c40397c1b9f11"
 dependencies = [
  "rgb",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "peeking_take_while"
@@ -778,12 +888,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.26"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
- "unicode-xid",
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -862,6 +996,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,14 +1049,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
-name = "syn"
-version = "1.0.70"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "syn"
+version = "1.0.107"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -976,16 +1130,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "vcpkg"
@@ -1073,6 +1227,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "ws2_32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["/samples", "/*.bat", "/*.sh"]
 # todo: make optional
 jpegxr = "0.2.1"
 png = "0.17.1"
-clap = "2.33.3"
+clap = { version = "4.1.6", features = [ "derive" ] }
 mtpng = "0.3.5"
 time = "0.3.3"
 notify = "4.0.17"

--- a/src/colormap.rs
+++ b/src/colormap.rs
@@ -1,0 +1,51 @@
+use glam::Vec3;
+
+use crate::transforms::*;
+
+/// Color mappings
+#[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum)]
+pub enum ColorMap {
+    Clip,
+    Darken,
+    Desaturate,
+}
+
+impl ColorMap {
+    pub fn map(&self, input: Vec3) -> Vec3 {
+        match self {
+            ColorMap::Clip => color_clip(input),
+            ColorMap::Darken => color_darken_oklab(input),
+            ColorMap::Desaturate => color_desat_oklab(input),
+        }
+    }
+}
+
+pub fn color_clip(input: Vec3) -> Vec3 {
+    clip(input)
+}
+
+pub fn color_desat_oklab(c_in: Vec3) -> Vec3 {
+    let max = c_in.max_element();
+    if max > 1.0 {
+        let c_in_oklab = scrgb_to_oklab(c_in);
+        let c_out = binary_search(c_in_oklab, 0.0, 1.0, desat_oklab, |rgb| {
+            close_enough(rgb.max_element(), 1.0)
+        });
+        clip(c_out)
+    } else {
+        c_in
+    }
+}
+
+pub fn color_darken_oklab(c_in: Vec3) -> Vec3 {
+    let max = c_in.max_element();
+    if max > 1.0 {
+        let c_in_oklab = scrgb_to_oklab(c_in);
+        let c_out = binary_search(c_in_oklab, 0.0, 1.0, darken_oklab, |rgb| {
+            close_enough(rgb.max_element(), 1.0)
+        });
+        clip(c_out)
+    } else {
+        c_in
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum LocalError {
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("numeric format error: {0}")]
+    ParseFloatError(#[from] core::num::ParseFloatError),
+    #[error("PNG decoding error: {0}")]
+    PNGDecodingError(#[from] png::DecodingError),
+    #[error("PNG input must be in 8bpp true color")]
+    PNGFormatError,
+    #[error("JPEG XR decoding error: {0}")]
+    JXRError(#[from] jpegxr::JXRError),
+    #[error("Invalid input file type")]
+    InvalidInputFile,
+    #[error("Invalid output file type")]
+    InvalidOutputFile,
+    #[error("Unsupported pixel format")]
+    UnsupportedPixelFormat,
+    #[error("Folder watch error")]
+    NotifyError(#[from] notify::Error),
+    #[error("Recv error")]
+    RecvError(#[from] std::sync::mpsc::RecvError),
+    #[error("Image format error")]
+    ImageError(#[from] image::ImageError),
+    #[error("JPEG write failure")]
+    JpegWriteFailure,
+}

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -1,0 +1,46 @@
+use rayon::prelude::*;
+use std::cmp::Ordering;
+
+use crate::{transforms::luma_scrgb, PixelBuffer};
+
+pub struct Histogram {
+    luma_vals: Vec<f32>,
+}
+
+impl Histogram {
+    pub fn new(source: &PixelBuffer) -> Self {
+        // @todo maybe do a proper histogram with buckets
+        // instead of sorting every pixel value
+        let mut luma_vals = Vec::<f32>::new();
+        source
+            .pixels()
+            .map(luma_scrgb)
+            .collect_into_vec(&mut luma_vals);
+        luma_vals.par_sort_unstable_by(|a, b| match a.partial_cmp(b) {
+            Some(ordering) => ordering,
+            None => Ordering::Equal,
+        });
+        Self { luma_vals }
+    }
+
+    pub fn percentile(&self, target: f32) -> f32 {
+        let max_index = self.luma_vals.len() - 1;
+        let target_index = (max_index as f32 * target / 100.0) as usize;
+        self.luma_vals[target_index]
+    }
+
+    pub fn average_below_percentile(&self, percent: f32) -> f32 {
+        let max = self.percentile(percent);
+        let (sum, count) = self
+            .luma_vals
+            .iter()
+            .fold((0.0f32, 0usize), |(sum, count), luma| {
+                if *luma > max {
+                    (sum, count)
+                } else {
+                    (sum + luma, count + 1)
+                }
+            });
+        sum / count as f32
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,0 +1,106 @@
+use std::{fs::File, io::Write, path::Path};
+
+use crate::{LocalError, PixelBuffer, PixelFormat};
+
+// Read an input PNG and return its size and contents
+// It must be a certain format (8bpp true color no alpha)
+pub fn read_png(filename: &Path) -> Result<PixelBuffer, LocalError> {
+    use png::Decoder;
+    use png::Transformations;
+
+    let mut decoder = Decoder::new(File::open(filename)?);
+    decoder.set_transformations(Transformations::IDENTITY);
+
+    let mut reader = decoder.read_info()?;
+    let info = reader.info();
+
+    if info.bit_depth != png::BitDepth::Eight {
+        return Err(LocalError::PNGFormatError);
+    }
+    if info.color_type != png::ColorType::Rgb {
+        return Err(LocalError::PNGFormatError);
+    }
+
+    let mut buffer = PixelBuffer::new(
+        info.width as usize,
+        info.height as usize,
+        PixelFormat::HDR8bit,
+    );
+    reader.next_frame(buffer.bytes_mut())?;
+
+    Ok(buffer)
+}
+
+pub fn read_jxr(filename: &Path) -> Result<PixelBuffer, LocalError> {
+    use jpegxr::ImageDecode;
+    use jpegxr::PixelFormat::*;
+    use jpegxr::Rect;
+
+    let input = File::open(filename)?;
+    let mut decoder = ImageDecode::with_reader(input)?;
+
+    let (width, height) = decoder.get_size()?;
+    let format = decoder.get_pixel_format()?;
+    let (bytes_per_pixel, buf_fmt) = match format {
+        PixelFormat128bppRGBAFloat => (16, PixelFormat::HDRFloat32),
+        PixelFormat64bppRGBAHalf => (8, PixelFormat::HDRFloat16),
+        _ => {
+            println!("Pixel format: {:?}", format);
+            return Err(LocalError::UnsupportedPixelFormat);
+        }
+    };
+
+    let stride = width as usize * bytes_per_pixel;
+    let mut buffer = PixelBuffer::new(width as usize, height as usize, buf_fmt);
+
+    let rect = Rect::new(0, 0, width, height);
+    decoder.copy(&rect, buffer.bytes_mut(), stride)?;
+
+    Ok(buffer)
+}
+
+pub fn write_png(filename: &Path, data: &PixelBuffer) -> Result<(), LocalError> {
+    use mtpng::encoder::{Encoder, Options};
+    use mtpng::ColorType;
+    use mtpng::{CompressionLevel, Header};
+
+    let writer = File::create(filename)?;
+
+    let mut options = Options::new();
+    options.set_compression_level(CompressionLevel::High)?;
+
+    let mut header = Header::new();
+    header.set_size(data.width as u32, data.height as u32)?;
+    header.set_color(ColorType::Truecolor, 8)?;
+
+    let mut encoder = Encoder::new(writer, &options);
+
+    encoder.write_header(&header)?;
+    encoder.write_image_rows(data.bytes())?;
+    encoder.finish()?;
+
+    Ok(())
+}
+
+pub fn write_jpeg(filename: &Path, data: &PixelBuffer) -> Result<(), LocalError> {
+    // @todo allow setting jpeg quality
+    // mozjpeg is much faster than image crate's encoder
+    std::panic::catch_unwind(|| {
+        use mozjpeg::{ColorSpace, Compress};
+        let mut c = Compress::new(ColorSpace::JCS_EXT_RGB);
+        c.set_size(data.width, data.height);
+        c.set_quality(95.0);
+        c.set_mem_dest(); // can't write direct to file?
+        c.start_compress();
+        if !c.write_scanlines(data.bytes()) {
+            panic!("error writing scanlines");
+        }
+        c.finish_compress();
+        let mut writer = File::create(filename).expect("error creating output file");
+        let data = c
+            .data_as_mut_slice()
+            .expect("error accessing JPEG output buffer");
+        writer.write_all(data).expect("error writing output file");
+    })
+    .map_err(|_| LocalError::JpegWriteFailure)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,238 @@
+use time::OffsetDateTime;
+
+mod pixelbuffer;
+pub use pixelbuffer::*;
+
+mod histogram;
+pub use histogram::Histogram;
+
+pub mod io;
+
+mod error;
+pub use error::LocalError;
+
+pub mod transforms;
+use transforms::*;
+
+mod tonemap;
+pub use tonemap::Tonemap;
+
+mod colormap;
+pub use colormap::ColorMap;
+
+/// Hdrfix options
+#[derive(Clone, Debug, PartialEq, clap::Parser)]
+pub struct Hdrfix {
+    /// Auto-exposure.
+    /// Input level or percentile of input data to average to re-expose to neutral 50% mid-tone on input. Default is 0.5, which passes input through unchanged.
+    #[clap(default_value = "0.5")]
+    pub auto_exposure: Level,
+
+    /// Exposure adjustment in stops, applied after any auto exposure adjustment. May be positive or negative in stops; defaults to 0, which does not change the exposure.
+    #[clap(default_value = "0")]
+    pub exposure: f32,
+
+    /// Method for mapping HDR into SDR domain.
+    #[clap(long, default_value = "hable")]
+    pub tone_map: Tonemap,
+
+    /// Max HDR luminance level for Reinhard algorithm, in nits or a percentile to be calculated from input data. The default is 100%, which represents the highest input value.
+    #[clap(long, default_value = "100%")]
+    pub hdr_max: Level,
+
+    /// Coefficient for how to scale saturation in tone mapping. 1.0 will desaturate linearly to the compression ratio; smaller values will desaturate more aggressively.
+    #[clap(long, default_value = "1")]
+    pub saturation: f32,
+
+    /// Method for mapping and fixing out of gamut colors.
+    #[clap(long, default_value = "clip")]
+    pub color_map: ColorMap,
+
+    /// Gamma power applied on input.
+    #[clap(long, default_value = "1.0")]
+    pub pre_gamma: f32,
+
+    /// Minimum input level to normalize to 0 when expanding input for processing. May be an absolute value in -infinity..infinity range or a percentile from 0% to 100%.
+    #[clap(long, default_value = "0.0")]
+    pub pre_levels_min: Level,
+
+    #[clap(long, default_value = "0")]
+    #[clap(long, default_value = "1.0")]
+    pub pre_levels_max: Level,
+
+    /// Gamma power applied on output.
+    #[clap(long, default_value = "1.0")]
+    pub post_gamma: f32,
+
+    /// Minimum output level to save when expanding final SDR output for saving. May be an absolute value in 0..1 range or a percentile from 0% to 100%.
+    #[clap(long, default_value = "0.0")]
+    pub post_levels_min: Level,
+
+    /// Maximum output level to save when expanding final SDR output for saving. May be an absolute value in 0..1 range or a percentile from 0% to 100%.")
+    #[clap(long, default_value = "1.0")]
+    pub post_levels_max: Level,
+}
+
+/// Context for hdr conversion functions
+pub struct Context {
+    pub scale: f32,
+    pub hdr_max: f32,
+    pub saturation: f32,
+    pub tone_map: Tonemap,
+    pub color_map: ColorMap,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Level {
+    Scalar(f32),
+    Percentile(f32),
+}
+
+impl std::str::FromStr for Level {
+    type Err = LocalError;
+
+    fn from_str(source: &str) -> Result<Self, Self::Err> {
+        match source.strip_suffix('%') {
+            Some(val) => Ok(Self::Percentile(val.parse()?)),
+            None => Ok(Self::Scalar(source.parse::<f32>()?)),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum PixelFormat {
+    SDR8bit,
+    HDR8bit,
+    HDRFloat16,
+    HDRFloat32,
+}
+
+impl Hdrfix {
+    pub fn apply(&self, source: PixelBuffer) -> Result<PixelBuffer, LocalError> {
+        use rayon::prelude::*;
+
+        let width = source.width as usize;
+        let height = source.height as usize;
+
+        let mut pre_histogram = Lazy::new(|| Histogram::new(&source));
+        let pre_levels_min = pre_histogram.level(self.pre_levels_min);
+        let pre_levels_max = pre_histogram.level(self.pre_levels_min);
+        let source = {
+            let mut dest = PixelBuffer::new(width, height, PixelFormat::HDRFloat32);
+            dest.fill(
+                source
+                    .pixels()
+                    .map(|rgb| apply_levels(rgb, pre_levels_min, pre_levels_max, self.pre_gamma)),
+            );
+            dest
+        };
+
+        let mut input_histogram =
+            Lazy::new(|| time_func("input histogram", || Ok(Histogram::new(&source))).unwrap());
+
+        let scale = exposure_scale(self.exposure) * 0.5
+            / match self.auto_exposure {
+                Level::Scalar(level) => level,
+                Level::Percentile(percent) => {
+                    input_histogram.force().average_below_percentile(percent)
+                }
+            };
+
+        let hdr_max = match self.hdr_max {
+            // hdr_max input is in nits if scalar, so scale it to scrgb
+            Level::Scalar(nits) => nits / SDR_WHITE,
+
+            // If given a percentile for hdr_max, detect from input histogram.
+            Level::Percentile(val) => input_histogram.force().percentile(val),
+        } * scale;
+
+        let options = Context {
+            scale,
+            hdr_max,
+            saturation: self.saturation,
+            tone_map: self.tone_map,
+            color_map: self.color_map,
+        };
+
+        let mut tone_mapped = PixelBuffer::new(width, height, PixelFormat::HDRFloat32);
+        time_func("hdr_to_sdr", || {
+            tone_mapped.fill(source.pixels().map(|rgb| hdr_to_sdr_pixel(rgb, &options)));
+            Ok(())
+        })?;
+
+        // apply histogram expansion and color gamut correction to output
+        let mut lazy_histogram = Lazy::new(|| {
+            time_func("levels histogram", || Ok(Histogram::new(&tone_mapped))).unwrap()
+        });
+        let post_levels_min = lazy_histogram.level(self.post_levels_min);
+        let post_levels_max = lazy_histogram.level(self.post_levels_max);
+
+        let mut dest = PixelBuffer::new(width, height, PixelFormat::SDR8bit);
+        time_func("output mapping", || {
+            dest.fill(tone_mapped.pixels().map(|rgb| {
+                // We have to color map again
+                // in case the histogram pushed things back out of gamut.
+                clip(options.color_map.map(apply_levels(
+                    rgb,
+                    post_levels_min,
+                    post_levels_max,
+                    self.post_gamma,
+                )))
+            }));
+            Ok(())
+        })?;
+
+        Ok(dest)
+    }
+}
+
+struct Lazy<T, F>
+where
+    F: (FnOnce() -> T),
+{
+    value: Option<T>,
+    func: Option<F>,
+}
+
+impl<T, F> Lazy<T, F>
+where
+    F: (FnOnce() -> T),
+{
+    fn new(func: F) -> Self {
+        Lazy {
+            value: None,
+            func: Some(func),
+        }
+    }
+
+    fn force(&mut self) -> &T {
+        if self.value.is_none() {
+            let func = self.func.take().unwrap();
+            self.value = Some(func());
+        }
+        self.value.as_ref().unwrap()
+    }
+}
+
+impl<F> Lazy<Histogram, F>
+where
+    F: (FnOnce() -> Histogram),
+{
+    fn level(&mut self, level: Level) -> f32 {
+        match level {
+            Level::Scalar(val) => val,
+            Level::Percentile(val) => self.force().percentile(val),
+        }
+    }
+}
+
+pub fn time_func<F, G>(msg: &str, func: F) -> Result<G, LocalError>
+where
+    F: FnOnce() -> Result<G, LocalError>,
+{
+    let start = OffsetDateTime::now_utc();
+    let result = func()?;
+    let delta = OffsetDateTime::now_utc() - start;
+    println!("{} in {} ms", msg, delta.as_seconds_f64() * 1000.0);
+    Ok(result)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,920 +1,48 @@
 #![warn(clippy::all)]
 
-use std::cmp::Ordering;
 use std::ffi::OsString;
-use std::fs::File;
-use std::io::{self, Write};
-use std::num;
 use std::path::Path;
-use std::sync::mpsc::{channel, RecvError};
+use std::sync::mpsc::channel;
 use std::time::Duration;
 
-// Math bits
-use glam::f32::{Mat3, Vec3};
-
 // CLI bits
-use clap::{Arg, App, ArgMatches};
-use time::OffsetDateTime;
-
-// Parallelism bits
-use rayon::prelude::*;
+use clap::Parser;
 
 // Directory watch bits
-use notify::{DebouncedEvent, RecursiveMode, RecommendedWatcher, Watcher};
+use notify::{DebouncedEvent, RecommendedWatcher, RecursiveMode, Watcher};
 
-// Error bits
-use thiserror::Error;
-
-type Result<T> = std::result::Result<T, LocalError>;
-
-// Color fun
-use oklab::{Oklab, linear_srgb_to_oklab, oklab_to_linear_srgb};
-
-// 16-bit floats
-use half::prelude::*;
-
-#[derive(Copy, Clone, Debug)]
-enum Level {
-    Scalar(f32),
-    Percentile(f32),
-}
-
-impl Level {
-    fn with_str(source: &str) -> Result<Self> {
-        match source.strip_suffix('%') {
-            Some(val) => Ok(Self::Percentile(val.parse()?)),
-            None => Ok(Self::Scalar(source.parse::<f32>()?)),
-        }
-    }
-}
-
-struct Options {
-    scale: f32,
-    hdr_max: f32,
-    saturation: f32,
-    tone_map: fn(Vec3, &Options) -> Vec3,
-    color_map: fn(Vec3) -> Vec3,
-}
-
-enum PixelFormat {
-    SDR8bit,
-    HDR8bit,
-    HDRFloat16,
-    HDRFloat32,
-}
-use PixelFormat::*;
-
-// Note: currently assumes stride == width
-struct PixelBuffer {
-    width: usize,
-    height: usize,
-    bytes_per_pixel: usize,
-    data: Vec::<u8>,
-
-    // If we wanted these could be traits
-    // but we don't need that level of complexity
-    read_rgb_func: fn(&[u8]) -> Vec3,
-    write_rgb_func: fn(&mut [u8], Vec3),
-}
-
-impl PixelBuffer {
-    fn new(width: usize, height: usize, format: PixelFormat) -> Self {
-        let bytes_per_pixel = match format {
-            SDR8bit | HDR8bit => 3,
-            HDRFloat16 => 8,
-            HDRFloat32 => 16,
-        };
-        let read_rgb_func = match format {
-            SDR8bit => read_srgb_rgb24,
-            HDR8bit => read_rec2100_rgb24,
-            HDRFloat16 => read_scrgb_rgb64half,
-            HDRFloat32 => read_scrgb_rgb128float
-        };
-        let write_rgb_func = match format {
-            SDR8bit => write_srgb_rgb24,
-            HDR8bit => write_rec2100_rgb24,
-            HDRFloat16 => write_scrgb_rgb64half,
-            HDRFloat32 => write_scrgb_rgb128float
-        };
-        let stride = width * bytes_per_pixel;
-        let size = stride * height;
-        let data = vec![0u8; size];
-
-        PixelBuffer {
-            width,
-            height,
-            bytes_per_pixel,
-            data,
-            read_rgb_func,
-            write_rgb_func
-        }
-    }
-
-    fn bytes(&self) -> &[u8] {
-        &self.data
-    }
-
-    fn bytes_mut(&mut self) -> &mut[u8] {
-        &mut self.data
-    }
-
-    fn par_iter(&self) -> impl IndexedParallelIterator<Item = &[u8]> {
-        self.data.par_chunks(self.bytes_per_pixel)
-    }
-
-    fn par_iter_mut(&mut self) -> impl IndexedParallelIterator<Item = &mut [u8]> {
-        self.data.par_chunks_mut(self.bytes_per_pixel)
-    }
-
-    fn pixels(&self) -> impl '_ + IndexedParallelIterator<Item = Vec3>
-    {
-        self.par_iter().map(self.read_rgb_func)
-    }
-
-    fn fill<T>(&mut self, source: T)
-    where T: IndexedParallelIterator<Item = Vec3>
-    {
-        let write_rgb_func = self.write_rgb_func;
-        self.par_iter_mut()
-            .zip(source)
-            .for_each(|(dest, rgb)| write_rgb_func(dest, rgb))
-    }
-}
-
-fn read_srgb_rgb24(_data: &[u8]) -> Vec3 {
-    panic!("not yet implemented");
-}
-
-fn write_srgb_rgb24(data: &mut [u8], val: Vec3)
-{
-    let gamma_out = linear_to_srgb(val);
-    let clipped = clip(gamma_out);
-    let scaled = clipped * 255.0;
-    data[0] = scaled.x as u8;
-    data[1] = scaled.y as u8;
-    data[2] = scaled.z as u8;
-}
-
-fn read_rec2100_rgb24(data: &[u8]) -> Vec3 {
-    let scale = Vec3::splat(1.0 / 255.0);
-    let rgb_rec2100 = Vec3::new(data[0] as f32, data[1] as f32, data[2] as f32) * scale;
-    let rgb_linear = pq_to_linear(rgb_rec2100);
-    rec2100_to_scrgb(rgb_linear)
-}
-
-fn write_rec2100_rgb24(_data: &mut [u8], _rgb: Vec3) {
-    panic!("not yet implemented");
-}
-
-fn read_scrgb_rgb64half(data: &[u8]) -> Vec3 {
-    let data_ref_f16: &f16 = unsafe {
-        std::mem::transmute(&data[0])
-    };
-    let data_f16 = unsafe {
-        std::slice::from_raw_parts(data_ref_f16, data.len())
-    };
-    Vec3::new(data_f16[0].to_f32(), data_f16[1].to_f32(), data_f16[2].to_f32())
-}
-
-fn write_scrgb_rgb64half(data: &mut [u8], rgb: Vec3) {
-    let data_ref_f16: &mut f16 = unsafe {
-        std::mem::transmute(&mut data[0])
-    };
-    let data_f16 = &mut unsafe {
-        std::slice::from_raw_parts_mut(data_ref_f16, data.len())
-    };
-    data_f16[0] = f16::from_f32(rgb.x);
-    data_f16[1] = f16::from_f32(rgb.y);
-    data_f16[2] = f16::from_f32(rgb.z);
-}
-
-fn read_scrgb_rgb128float(data: &[u8]) -> Vec3 {
-    let data_ref_f32: &f32 = unsafe {
-        std::mem::transmute(&data[0])
-    };
-    let data_f32 = unsafe {
-        std::slice::from_raw_parts(data_ref_f32, data.len())
-    };
-    Vec3::new(data_f32[0], data_f32[1], data_f32[2])
-}
-
-fn write_scrgb_rgb128float(data: &mut [u8], rgb: Vec3) {
-    let data_ref_f32: &mut f32 = unsafe {
-        std::mem::transmute(&mut data[0])
-    };
-    let data_f32 = &mut unsafe {
-        std::slice::from_raw_parts_mut(data_ref_f32, data.len())
-    };
-    data_f32[0] = rgb.x;
-    data_f32[1] = rgb.y;
-    data_f32[2] = rgb.z;
-}
-
-
-#[derive(Error, Debug)]
-enum LocalError {
-    #[error("I/O error: {0}")]
-    IoError(#[from] io::Error),
-    #[error("numeric format error: {0}")]
-    ParseFloatError(#[from] num::ParseFloatError),
-    #[error("PNG decoding error: {0}")]
-    PNGDecodingError(#[from] png::DecodingError),
-    #[error("PNG input must be in 8bpp true color")]
-    PNGFormatError,
-    #[error("JPEG XR decoding error: {0}")]
-    JXRError(#[from] jpegxr::JXRError),
-    #[error("Invalid input file type")]
-    InvalidInputFile,
-    #[error("Invalid output file type")]
-    InvalidOutputFile,
-    #[error("Unsupported pixel format")]
-    UnsupportedPixelFormat,
-    #[error("Folder watch error")]
-    NotifyError(#[from] notify::Error),
-    #[error("Recv error")]
-    RecvError(#[from] RecvError),
-    #[error("Image format error")]
-    ImageError(#[from] image::ImageError),
-    #[error("JPEG write failure")]
-    JpegWriteFailure,
-}
-use LocalError::*;
-
-fn time_func<F, G>(msg: &str, func: F) -> Result<G>
-    where F: FnOnce() -> Result<G>
-{
-    let start = OffsetDateTime::now_utc();
-    let result = func()?;
-    let delta = OffsetDateTime::now_utc() - start;
-    println!("{} in {} ms", msg, delta.as_seconds_f64() * 1000.0);
-    Ok(result)
-}
-
-// Read an input PNG and return its size and contents
-// It must be a certain format (8bpp true color no alpha)
-fn read_png(filename: &Path)
-    -> Result<PixelBuffer>
-{
-    use png::Decoder;
-    use png::Transformations;
-
-    let mut decoder = Decoder::new(File::open(filename)?);
-    decoder.set_transformations(Transformations::IDENTITY);
-
-    let mut reader = decoder.read_info()?;
-    let info = reader.info();
-
-    if info.bit_depth != png::BitDepth::Eight {
-        return Err(PNGFormatError);
-    }
-    if info.color_type != png::ColorType::Rgb {
-        return Err(PNGFormatError);
-    }
-
-    let mut buffer = PixelBuffer::new(
-        info.width as usize,
-        info.height as usize,
-        HDR8bit
-    );
-    reader.next_frame(buffer.bytes_mut())?;
-
-    Ok(buffer)
-}
-
-fn read_jxr(filename: &Path)
-  -> Result<PixelBuffer>
-{
-    use jpegxr::ImageDecode;
-    use jpegxr::PixelFormat::*;
-    use jpegxr::Rect;
-
-    let input = File::open(filename)?;
-    let mut decoder = ImageDecode::with_reader(input)?;
-
-    let (width, height) = decoder.get_size()?;
-    let format = decoder.get_pixel_format()?;
-    let (bytes_per_pixel, buf_fmt) = match format {
-        PixelFormat128bppRGBAFloat => {
-            (16, HDRFloat32)
-        },
-        PixelFormat64bppRGBAHalf => {
-            (8, HDRFloat16)
-        },
-        _ => {
-            println!("Pixel format: {:?}", format);
-            return Err(UnsupportedPixelFormat);
-        }
-    };
-
-    let stride = width as usize * bytes_per_pixel;
-    let mut buffer = PixelBuffer::new(
-        width as usize,
-        height as usize,
-        buf_fmt
-    );
-
-    let rect = Rect::new(0, 0, width, height);
-    decoder.copy(&rect, buffer.bytes_mut(), stride)?;
-
-    Ok(buffer)
-}
-
-fn pq_to_linear(val: Vec3) -> Vec3 {
-    // fixme make sure all the splats are efficient constants
-    let inv_m1: f32 = 1.0 / 0.15930176;
-    let inv_m2: f32 = 1.0 / 78.84375;
-    let c1 = Vec3::splat(0.8359375);
-    let c2 = Vec3::splat(18.851563);
-    let c3 = Vec3::splat(18.6875);
-    let val_powered = val.powf(inv_m2);
-    (Vec3::max(val_powered - c1, Vec3::ZERO)
-        / (c2 - c3 * val_powered)
-    ).powf(inv_m1)
-}
-
-fn rec2100_to_scrgb(val: Vec3) -> Vec3 {
-    let matrix = Mat3::from_cols_array(&[
-        1.6605, -0.1246, -0.0182,
-        -0.5876, 1.1329, -0.1006,
-        -0.0728, -0.0083, 1.1187
-    ]);
-    let scale = REC2100_MAX / SDR_WHITE;
-    matrix.mul_vec3(val * scale)
-}
-
-fn luma_scrgb(val: Vec3) -> f32 {
-    luma_oklab(scrgb_to_oklab(val))
-}
-
-fn luma_oklab(val: Oklab) -> f32 {
-    // oklab's l is not linear
-    // so translate it back to linear srgb desaturated
-    // and take one of its rgb values
-    let oklab_gray = Oklab {
-        l: val.l,
-        a: 0.0,
-        b: 0.0,
-    };
-    let rgb_gray = oklab_to_scrgb(oklab_gray);
-    rgb_gray.x
-}
-
-fn tonemap_linear(c_in: Vec3, _options: &Options) -> Vec3 {
-    c_in
-}
-
-fn tonemap_reinhard_rgb(c_in: Vec3, options: &Options) -> Vec3 {
-    // Variant that maps R, G, and B channels separately.
-    // This should desaturate very bright colors gradually, but will
-    // possible cause some color shift.
-    let white = options.hdr_max;
-    let white2 = white * white;
-    c_in * (Vec3::ONE + c_in / white2) / (Vec3::ONE + c_in)
-}
-
-fn tonemap_reinhard_oklab(c_in: Vec3, options: &Options) -> Vec3 {
-    // Map luminance from HDR to SDR domain, and scale the input color
-    // in oklab perceptual color space.
-    //
-    // oklab color space: https://bottosson.github.io/posts/oklab/
-    //
-    let white = options.hdr_max;
-    let white2 = white * white;
-
-    // use Oklab's L coordinate as luminance
-    let oklab_in = scrgb_to_oklab(c_in);
-    let luma_in = luma_oklab(oklab_in);
-
-    // Reinhard tone-mapping algo.
-    //
-    // Original:
-    // http://www.cmap.polytechnique.fr/%7Epeyre/cours/x2005signal/hdr_photographic.pdf
-    //
-    // Extended:
-    // https://64.github.io/tonemapping/#reinhard
-    // TMO_reinhardext​(C) = C(1 + C/C_white^2​) / (1 + C)
-    //
-    let luma_out = luma_in * (1.0 + luma_in / white2) / (1.0 + luma_in);
-    let oklab_out = scale_oklab_desat(oklab_in, luma_out, options.saturation);
-    oklab_to_scrgb(oklab_out)
-}
-
-fn oklab_l_for_luma(luma: f32) -> f32 {
-    let gray_rgb = oklab::RGB::new(luma, luma, luma);
-    let gray_oklab = linear_srgb_to_oklab(gray_rgb);
-    gray_oklab.l
-}
-
-fn scale_oklab_desat(oklab_in: Oklab, luma_out: f32, saturation: f32) -> Oklab
-{
-    let l_in = oklab_in.l;
-    if l_in == 0.0 {
-        oklab_in
-    } else {
-        let l_out = oklab_l_for_luma(luma_out);
-        // oklab coords scale cubically
-        // 1.0 -> desaturate linearly according to luma compression ratio
-        // 0.5 -> desaturate more aggressively
-        // 2.0 -> saturate more aggressively
-        let ratio = (l_out / l_in).powf(3.0 / saturation);
-        Oklab {
-            l: l_out,
-            a: oklab_in.a * ratio,
-            b: oklab_in.b * ratio,
-        }
-    }
-}
-
-fn scale_oklab(oklab_in: Oklab, luma_out: f32) -> Oklab
-{
-    if oklab_in.l == 0.0 {
-        oklab_in
-    } else {
-        let gray_l = oklab_l_for_luma(luma_out);
-        let ratio = gray_l / oklab_in.l;
-        Oklab {
-            l: gray_l,
-            a: oklab_in.a * ratio,
-            b: oklab_in.b * ratio,
-        }
-    }
-}
-
-fn clip(input: Vec3) -> Vec3 {
-    input.max(Vec3::ZERO).min(Vec3::ONE)
-}
-
-fn color_clip(input: Vec3) -> Vec3
-{
-    clip(input)
-}
-
-fn darken_oklab(c_in: Oklab, brightness: f32) -> Vec3
-{
-    let c_out = Oklab {
-        l: c_in.l * brightness,
-        a: c_in.a * brightness,
-        b: c_in.b * brightness,
-    };
-    oklab_to_scrgb(c_out)
-}
-
-fn desat_oklab(c_in: Oklab, saturation: f32) -> Vec3
-{
-    let c_out = Oklab {
-        l: c_in.l,
-        a: c_in.a * saturation,
-        b: c_in.b * saturation,
-    };
-    oklab_to_scrgb(c_out)
-}
-
-const EPSILON: f32 = 0.001; // good enough for us for now
-
-fn close_enough(a: f32, b: f32) -> Ordering {
-    let delta = a - b;
-    if delta.abs() < EPSILON {
-        Ordering::Equal
-    } else if delta < 0.0 {
-        Ordering::Less
-    } else {
-        Ordering::Greater
-    }
-}
-
-fn binary_search<I, O, F, G>(input: I, min: f32, max: f32, func: F, comparator: G) -> O
-where I: Copy + Clone,
-    O: Copy + Clone,
-    F: Fn(I, f32) -> O,
-    G: Fn(O) -> Ordering
-{
-    let mid = (min + max) / 2.0;
-    let result = func(input, mid);
-    match close_enough(min, max) {
-        Ordering::Equal => result,
-        _ => match comparator(result) {
-            Ordering::Less => binary_search(input, mid, max, func, comparator),
-            Ordering::Greater => binary_search(input, min, mid, func, comparator),
-            Ordering::Equal => result,
-        }
-    }
-}
-
-fn color_darken_oklab(c_in: Vec3) -> Vec3
-{
-    let max = c_in.max_element();
-    if max > 1.0 {
-        let c_in_oklab = scrgb_to_oklab(c_in);
-        let c_out = binary_search(c_in_oklab, 0.0, 1.0, darken_oklab, |rgb| {
-            close_enough(rgb.max_element(), 1.0)
-        });
-        clip(c_out)
-    } else {
-        c_in
-    }
-}
-
-fn color_desat_oklab(c_in: Vec3) -> Vec3
-{
-    let max = c_in.max_element();
-    if max > 1.0 {
-        let c_in_oklab = scrgb_to_oklab(c_in);
-        let c_out = binary_search(c_in_oklab, 0.0, 1.0, desat_oklab, |rgb| {
-            close_enough(rgb.max_element(), 1.0)
-        });
-        clip(c_out)
-    } else {
-        c_in
-    }
-}
-
-fn luma_rgb(val: Vec3) -> f32 {
-    val.x * 0.2126 + val.y * 0.7152 + val.z * 0.0722
-}
-
-fn scale_rgb(val: Vec3, luma_out: f32) -> Vec3 {
-    let luma_in = luma_rgb(val);
-    let scale = luma_out / luma_in;
-    val * scale
-}
-
-// https://64.github.io/tonemapping/#uncharted-2
-// Uncharted 2 / Hable Filmic
-fn uncharted2_tonemap_partial(x: f32) -> f32
-{
-    const A: f32 = 0.15;
-    const B: f32 = 0.50;
-    const C: f32 = 0.10;
-    const D: f32 = 0.20;
-    const E: f32 = 0.02;
-    const F: f32 = 0.30;
-    ((x*(A*x+(C*B))+(D*E))/(x*(A*x+(B))+(D*F)))-(E/F)
-}
-
-fn tonemap_uncharted2(v: Vec3, _options: &Options) -> Vec3
-{
-    let exposure_bias: f32 = 2.0;
-    let luma = luma_rgb(v);
-    let curr = uncharted2_tonemap_partial(luma * exposure_bias);
-
-    let w = 11.2f32;
-    let white_scale = 1.0f32 / uncharted2_tonemap_partial(w);
-    let luma_out = curr * white_scale;
-
-    scale_rgb(v, luma_out)
-}
-
-fn tonemap_hable(val: Vec3, _options: &Options) -> Vec3
-{
-    // stolen from ffmpeg's vf_tonemap
-
-    // desat
-    let luma = luma_rgb(val);
-    let desaturation: f32 = 2.0;
-    let epsilon: f32 = 1e-6;
-    let overbright = f32::max(luma - desaturation, epsilon ) / f32::max(luma, epsilon);
-    let rgb_out = val * (1.0 - overbright) + luma * overbright;
-    let sig_orig = f32::max(rgb_out.max_element(), epsilon);
-
-    // hable/uncharted2
-    let exposure_bias: f32 = 2.0;
-    let luma = sig_orig;
-    let curr = uncharted2_tonemap_partial(luma * exposure_bias);
-    let w = 11.2f32;
-    let white_scale = 1.0f32 / uncharted2_tonemap_partial(w);
-    let sig = curr * white_scale;
-
-    rgb_out * (sig / sig_orig)
-}
-
-// can't use glam's Mat3 as a constant literal?
-type Matrix3x3 = [[f32; 3]; 3];
-
-// https://64.github.io/tonemapping/#aces
-// ACES (Academy Color Encoding System)
-const ACES_INPUT_MATRIX: Matrix3x3 =
-[
-    [0.59719, 0.35458, 0.04823],
-    [0.07600, 0.90834, 0.01566],
-    [0.02840, 0.13383, 0.83777]
-];
-
-const ACES_OUTPUT_MATRIX: Matrix3x3 =
-[
-    [ 1.60475, -0.53108, -0.07367],
-    [-0.10208,  1.10813, -0.00605],
-    [-0.00327, -0.07276,  1.07602]
-];
-
-#[allow(clippy::many_single_char_names)]
-fn aces_mul(m: &Matrix3x3, v: Vec3) -> Vec3
-{
-    let x = m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2];
-    let y = m[1][0] * v[1] + m[1][1] * v[1] + m[1][2] * v[2];
-    let z = m[2][0] * v[1] + m[2][1] * v[1] + m[2][2] * v[2];
-    Vec3::new(x, y, z)
-}
-
-fn aces_rtt_and_odt_fit(v: Vec3) -> Vec3
-{
-    let a = v * (v + Vec3::splat(0.0245786)) - Vec3::splat(0.000090537);
-    let b = v * (Vec3::splat(0.983729) * v + Vec3::splat(0.432951)) + Vec3::splat(0.238081);
-    a / b
-}
-
-fn tonemap_aces(c_in: Vec3, _options: &Options) -> Vec3 {
-    let v = c_in;
-    let v = aces_mul(&ACES_INPUT_MATRIX, v);
-    let v = aces_rtt_and_odt_fit(v);
-    aces_mul(&ACES_OUTPUT_MATRIX, v)
-}
-
-/*
-fn srgb_to_linear(val: Vec3) -> Vec3 {
-    Vec3::select(
-        val.cmple(Vec3::splat(0.04045)),
-        val / Vec3::splat(12.92),
-        ((val + Vec3::splat(0.055)) / Vec3::splat(1.055)).powf(2.4)
-    )
-}
-*/
-
-fn linear_to_srgb(val: Vec3) -> Vec3 {
-    // fixme make sure all the splats are efficient constants
-    let min = Vec3::splat(0.0031308);
-    let linear = val * Vec3::splat(12.92);
-    let gamma = (val * Vec3::splat(1.055)).powf(1.0 / 2.4) - Vec3::splat(0.055);
-    Vec3::select(val.cmple(min), linear, gamma)
-}
-
-const REC2100_MAX: f32 = 10000.0; // the 1.0 value for BT.2100 linear
-const SDR_WHITE: f32 = 80.0;
-
-fn exposure_scale(stops: f32) -> f32
-{
-    2.0_f32.powf(stops)
-}
-
-fn hdr_to_sdr_pixel(rgb_scrgb: Vec3, options: &Options) -> Vec3
-{
-    let val = rgb_scrgb * options.scale;
-    let val = (options.tone_map)(val, options);
-    (options.color_map)(val)
-}
-
-fn write_png(filename: &Path, data: &PixelBuffer)
-   -> Result<()>
-{
-    use mtpng::{CompressionLevel, Header};
-    use mtpng::encoder::{Encoder, Options};
-    use mtpng::ColorType;
-
-    let writer = File::create(filename)?;
-
-    let mut options = Options::new();
-    options.set_compression_level(CompressionLevel::High)?;
-
-    let mut header = Header::new();
-    header.set_size(data.width as u32, data.height as u32)?;
-    header.set_color(ColorType::Truecolor, 8)?;
-
-    let mut encoder = Encoder::new(writer, &options);
-
-    encoder.write_header(&header)?;
-    encoder.write_image_rows(data.bytes())?;
-    encoder.finish()?;
-
-    Ok(())
-}
-
-
-fn write_jpeg(filename: &Path, data: &PixelBuffer)
-   -> Result<()>
-{
-    // @todo allow setting jpeg quality
-    // mozjpeg is much faster than image crate's encoder
-    std::panic::catch_unwind(|| {
-        use mozjpeg::{Compress, ColorSpace};
-        let mut c = Compress::new(ColorSpace::JCS_EXT_RGB);
-        c.set_size(data.width, data.height);
-        c.set_quality(95.0);
-        c.set_mem_dest(); // can't write direct to file?
-        c.start_compress();
-        if !c.write_scanlines(data.bytes()) {
-            panic!("error writing scanlines");
-        }
-        c.finish_compress();
-        let mut writer = File::create(filename).expect("error creating output file");
-        let data = c.data_as_mut_slice().expect("error accessing JPEG output buffer");
-        writer.write_all(data).expect("error writing output file");
-    }).map_err(|_| JpegWriteFailure)
-}
-
-struct Histogram {
-    luma_vals: Vec<f32>,
-}
-
-impl Histogram {
-    fn new(source: &PixelBuffer) -> Self {
-        // @todo maybe do a proper histogram with buckets
-        // instead of sorting every pixel value
-        let mut luma_vals = Vec::<f32>::new();
-        source.pixels().map(luma_scrgb).collect_into_vec(&mut luma_vals);
-        luma_vals.par_sort_unstable_by(|a, b| {
-            match a.partial_cmp(b) {
-                Some(ordering) => ordering,
-                None => Ordering::Equal,
-            }
-        });
-        Self {
-            luma_vals
-        }
-    }
-
-    fn percentile(&self, target: f32) -> f32 {
-        let max_index = self.luma_vals.len() - 1;
-        let target_index = (max_index as f32 * target / 100.0) as usize;
-        self.luma_vals[target_index]
-    }
-
-    fn average_below_percentile(&self, percent: f32) -> f32 {
-        let max = self.percentile(percent);
-        let (sum, count) = self.luma_vals.iter().fold((0.0f32, 0usize), |(sum, count), luma| {
-            if *luma > max {
-                (sum, count)
-            } else {
-                (sum + luma, count + 1)
-            }
-        });
-        sum / count as f32
-    }
-}
-
-fn scrgb_to_linear_srgb(c: Vec3) -> oklab::RGB<f32> {
-    oklab::RGB::new(c.x, c.y, c.z)
-}
-
-fn linear_srgb_to_scrgb(c: oklab::RGB<f32>) -> Vec3 {
-    Vec3::new(c.r, c.g, c.b)
-}
-
-fn scrgb_to_oklab(c: Vec3) -> Oklab {
-    linear_srgb_to_oklab(scrgb_to_linear_srgb(c))
-}
-
-fn oklab_to_scrgb(c: Oklab) -> Vec3 {
-    linear_srgb_to_scrgb(oklab_to_linear_srgb(c))
-}
-
-fn apply_levels(c_in: Vec3, level_min: f32, level_max: f32, gamma: f32) -> Vec3 {
-    let offset = level_min;
-    let scale = level_max - level_min;
-    let oklab_in = scrgb_to_oklab(c_in);
-    let luma_in = luma_oklab(oklab_in);
-    let luma_out = ((luma_in - offset) / scale).powf(gamma);
-    let oklab_out = scale_oklab(oklab_in, luma_out);
-    oklab_to_scrgb(oklab_out)
-}
-
-struct Lazy<T, F> where F: (FnOnce() -> T) {
-    value: Option<T>,
-    func: Option<F>,
-}
-
-impl<T,F> Lazy<T,F> where F: (FnOnce() -> T) {
-    fn new(func: F) -> Self {
-        Lazy {
-            value: None,
-            func: Some(func)
-        }
-    }
-
-    fn force(&mut self) -> &T {
-        if self.value.is_none() {
-            let func = self.func.take().unwrap();
-            self.value = Some(func());
-        }
-        self.value.as_ref().unwrap()
-    }
-}
-
-impl<F> Lazy<Histogram,F> where F: (FnOnce() -> Histogram) {
-    fn level(&mut self, level: Level) -> f32 {
-        match level {
-            Level::Scalar(val) => val,
-            Level::Percentile(val) => self.force().percentile(val),
-        }
-    }
-}
+// Hdrfix library
+use hdrfix::{io::*, time_func, Hdrfix, LocalError};
 
 fn extension(input_filename: &Path) -> &str {
     input_filename.extension().unwrap().to_str().unwrap()
 }
 
-fn hdrfix(input_filename: &Path, output_filename: &Path, args: &ArgMatches) -> Result<()>
-{
-    println!("{} -> {}", input_filename.to_str().unwrap(), output_filename.to_str().unwrap());
+/// hdrfix converter for HDR screenshots
+#[derive(Clone, Debug, PartialEq, clap::Parser)]
+pub struct Args {
+    /// Input filename, must be .jxr or .png as saved by NVIDIA capture overlay.
+    #[clap()]
+    pub input_file: Option<String>,
 
-    let source = time_func("read_input", || {
-        let ext = extension(input_filename);
-        match ext {
-            "png" => read_png(input_filename),
-            "jxr" => read_jxr(input_filename),
-            _ => Err(InvalidInputFile)
-        }
-    })?;
-    let width = source.width as usize;
-    let height = source.height as usize;
+    /// Output filename, must be .png
+    #[clap()]
+    pub output_file: Option<String>,
 
-    let pre_gamma: f32 = args.value_of("pre-gamma").expect("pre-gamma arg").parse()?;
-    let mut pre_histogram = Lazy::new(|| Histogram::new(&source));
-    let pre_levels_min = pre_histogram.level(Level::with_str(args.value_of("pre-levels-min").expect("pre-levels-min arg"))?);
-    let pre_levels_max = pre_histogram.level(Level::with_str(args.value_of("pre-levels-max").expect("pre-levels-max arg"))?);
-    let source = {
-        let mut dest = PixelBuffer::new(width, height, PixelFormat::HDRFloat32);
-        dest.fill(source.pixels().map(|rgb| apply_levels(rgb, pre_levels_min, pre_levels_max, pre_gamma)));
-        dest
-    };
+    #[clap(flatten)]
+    pub opts: Hdrfix,
 
-
-    let mut input_histogram = Lazy::new(|| time_func("input histogram", || {
-        Ok(Histogram::new(&source))
-    }).unwrap());
-
-    let exposure = args.value_of("exposure").unwrap().parse::<f32>()?;
-    let auto_exposure = Level::with_str(args.value_of("auto-exposure").unwrap())?;
-    let scale = exposure_scale(exposure) * 0.5 / match auto_exposure {
-        Level::Scalar(level) => level,
-        Level::Percentile(percent) => input_histogram.force().average_below_percentile(percent),
-    };
-
-    let hdr_max = match Level::with_str(args.value_of("hdr-max").unwrap())? {
-        // hdr_max input is in nits if scalar, so scale it to scrgb
-        Level::Scalar(nits) => nits / SDR_WHITE,
-
-        // If given a percentile for hdr_max, detect from input histogram.
-        Level::Percentile(val) => input_histogram.force().percentile(val),
-    } * scale;
-
-    let options = Options {
-        scale,
-        hdr_max,
-        saturation: args.value_of("saturation").expect("saturation arg").parse()?,
-        tone_map: match args.value_of("tone-map").expect("tone-map arg") {
-            "linear" => tonemap_linear,
-            "reinhard" => tonemap_reinhard_oklab,
-            "reinhard-rgb" => tonemap_reinhard_rgb,
-            "aces" => tonemap_aces,
-            "uncharted2" => tonemap_uncharted2,
-            "hable" => tonemap_hable,
-            _ => unreachable!("bad tone-map option")
-        },
-        color_map: match args.value_of("color-map").expect("color-map arg") {
-            "clip" => color_clip,
-            "darken" => color_darken_oklab,
-            "desaturate" => color_desat_oklab,
-            _ => unreachable!("bad color-map option")
-        },
-    };
-
-    let mut tone_mapped = PixelBuffer::new(width, height, HDRFloat32);
-    time_func("hdr_to_sdr", || {
-        tone_mapped.fill(source.pixels().map(|rgb| hdr_to_sdr_pixel(rgb, &options)));
-        Ok(())
-    })?;
-
-    // apply histogram expansion and color gamut correction to output
-    let mut lazy_histogram = Lazy::new(|| {
-        time_func("levels histogram", || Ok(Histogram::new(&tone_mapped))).unwrap()
-    });
-    let post_levels_min = lazy_histogram.level(Level::with_str(args.value_of("post-levels-min").expect("post-levels-min arg"))?);
-    let post_levels_max = lazy_histogram.level(Level::with_str(args.value_of("post-levels-max").expect("post-levels-max arg"))?);
-    let post_gamma: f32 = args.value_of("post-gamma").expect("post-gamma arg").parse()?;
-
-    let mut dest = PixelBuffer::new(width, height, SDR8bit);
-    time_func("output mapping", || {
-        dest.fill(tone_mapped.pixels().map(|rgb| {
-            // We have to color map again
-            // in case the histogram pushed things back out of gamut.
-            clip((options.color_map)(apply_levels(rgb, post_levels_min, post_levels_max, post_gamma)))
-        }));
-        Ok(())
-    })?;
-
-    time_func("write output", || {
-        let ext = extension(output_filename);
-        match ext {
-            "png" => write_png(output_filename, &dest),
-            "jpg" | "jpeg" => write_jpeg(output_filename, &dest),
-            _ => Err(InvalidOutputFile)
-        }
-    })?;
-
-    Ok(())
+    /// Watch a folder and convert any *.jxr files that appear into *-sdr.jpg versions. Provide a folder name.
+    #[clap(long)]
+    pub watch: Option<String>,
 }
 
-fn run(args: &ArgMatches) -> Result<()> {
-    match args.value_of("watch") {
+fn main() -> Result<(), LocalError> {
+    // Parse command line arguments
+    let args = Args::parse();
+
+    // Handle watch mode
+    match &args.watch {
         Some(folder) => {
             let (tx, rx) = channel::<DebouncedEvent>();
             let mut watcher = RecommendedWatcher::new(tx, Duration::from_secs(2))?;
@@ -925,92 +53,68 @@ fn run(args: &ArgMatches) -> Result<()> {
                 if let DebouncedEvent::Create(input_path) = event {
                     let ext = extension(&input_path);
                     if ext == "jxr" {
-                        let mut output_filename: OsString = input_path.file_stem().unwrap().to_os_string();
+                        let mut output_filename: OsString =
+                            input_path.file_stem().unwrap().to_os_string();
                         output_filename.push("-sdr.jpg");
                         let output_path = input_path.with_file_name(output_filename);
                         if !output_path.exists() {
-                            hdrfix(&input_path, &output_path, args)?;
+                            hdrfix(&input_path, &output_path, &args.opts)?;
                         }
                     }
                 }
             }
-        },
+        }
         None => {
-            let input_filename = Path::new(args.value_of("input").expect("input filename missing"));
-            let output_filename = Path::new(args.value_of("output").expect("output filename missing"));
-            hdrfix(input_filename, output_filename, args)
+            let input_file = args
+                .input_file
+                .as_ref()
+                .map(Path::new)
+                .expect("input filename missing");
+            let output_file = args
+                .output_file
+                .as_ref()
+                .map(Path::new)
+                .expect("output filename missing");
+            hdrfix(input_file, output_file, &args.opts)?;
         }
     }
+
+    Ok(())
 }
 
-fn main() {
-    let args = App::new("hdrfix converter for HDR screenshots")
-        .version("0.1.0")
-        .author("Brion Vibber <brion@pobox.com>")
-        .arg(Arg::with_name("input")
-            .help("Input filename, must be .jxr or .png as saved by NVIDIA capture overlay.")
-            .index(1))
-        .arg(Arg::with_name("output")
-            .help("Output filename, must be .png.")
-            .index(2))
-        .arg(Arg::with_name("auto-exposure")
-            .help("Input level or percentile of input data to average to re-expose to neutral 50% mid-tone on input. Default is 0.5, which passes input through unchanged.")
-            .long("auto-exposure")
-            .default_value("0.5"))
-        .arg(Arg::with_name("exposure")
-            .help("Exposure adjustment in stops, applied after any auto exposure adjustment. May be positive or negative in stops; defaults to 0, which does not change the exposure.")
-            .long("exposure")
-            .default_value("0"))
-        .arg(Arg::with_name("tone-map")
-            .help("Method for mapping HDR into SDR domain.")
-            .long("tone-map")
-            .possible_values(&["linear", "reinhard", "reinhard-rgb", "aces", "uncharted2", "hable"])
-            .default_value("hable"))
-        .arg(Arg::with_name("hdr-max")
-            .help("Max HDR luminance level for Reinhard algorithm, in nits or a percentile to be calculated from input data. The default is 100%, which represents the highest input value.")
-            .long("hdr-max")
-            .default_value("100%"))
-        .arg(Arg::with_name("saturation")
-            .help("Coefficient for how to scale saturation in tone mapping. 1.0 will desaturate linearly to the compression ratio; smaller values will desaturate more aggressively.")
-            .long("saturation")
-            .default_value("1"))
-        .arg(Arg::with_name("color-map")
-            .help("Method for mapping and fixing out of gamut colors.")
-            .long("color-map")
-            .possible_values(&["clip", "darken", "desaturate", "desaturate-oklab"])
-            .default_value("clip"))
-        .arg(Arg::with_name("pre-gamma")
-            .help("Gamma power applied on input.")
-            .long("pre-gamma")
-            .default_value("1.0"))
-        .arg(Arg::with_name("pre-levels-min")
-            .help("Minimum input level to normalize to 0 when expanding input for processing. May be an absolute value in -infinity..infinity range or a percentile from 0% to 100%.")
-            .long("pre-levels-min")
-            .default_value("0.0"))
-        .arg(Arg::with_name("pre-levels-max")
-            .help("Maximum input level to normalize to 1 when expanding input for processing. May be an absolute value in -infinity..infinity range or a percentile from 0% to 100%.")
-            .long("pre-levels-max")
-            .default_value("1.0"))
-        .arg(Arg::with_name("post-gamma")
-            .help("Gamma power applied on output.")
-            .long("post-gamma")
-            .default_value("1.0"))
-        .arg(Arg::with_name("post-levels-min")
-            .help("Minimum output level to save when expanding final SDR output for saving. May be an absolute value in 0..1 range or a percentile from 0% to 100%.")
-            .long("post-levels-min")
-            .default_value("0.0"))
-        .arg(Arg::with_name("post-levels-max")
-            .help("Maximum output level to save when expanding final SDR output for saving. May be an absolute value in 0..1 range or a percentile from 0% to 100%.")
-            .long("post-levels-max")
-            .default_value("1.0"))
-        .arg(Arg::with_name("watch")
-            .help("Watch a folder and convert any *.jxr files that appear into *-sdr.jpg versions. Provide a folder name.")
-            .long("watch")
-            .takes_value(true))
-        .get_matches();
+fn hdrfix(
+    input_filename: &Path,
+    output_filename: &Path,
+    hdrfix: &Hdrfix,
+) -> Result<(), LocalError> {
+    println!(
+        "{} -> {}",
+        input_filename.to_str().unwrap(),
+        output_filename.to_str().unwrap()
+    );
 
-    match run(&args) {
-        Ok(_) => println!("Done."),
-        Err(e) => eprintln!("Error: {}", e),
-    }
+    // Load input file
+    let source = time_func("read_input", || {
+        let ext = extension(input_filename);
+        match ext {
+            "png" => read_png(input_filename),
+            "jxr" => read_jxr(input_filename),
+            _ => Err(LocalError::InvalidInputFile),
+        }
+    })?;
+
+    // Apply hdrfix
+    let dest = hdrfix.apply(source)?;
+
+    // Write output file
+    time_func("write output", || {
+        let ext = extension(output_filename);
+        match ext {
+            "png" => write_png(output_filename, &dest),
+            "jpg" | "jpeg" => write_jpeg(output_filename, &dest),
+            _ => Err(LocalError::InvalidOutputFile),
+        }
+    })?;
+
+    Ok(())
 }

--- a/src/pixelbuffer.rs
+++ b/src/pixelbuffer.rs
@@ -1,0 +1,81 @@
+use glam::Vec3;
+use rayon::prelude::*;
+
+use crate::{transforms::*, PixelFormat};
+
+// Note: currently assumes stride == width
+pub struct PixelBuffer {
+    pub width: usize,
+    pub height: usize,
+    pub bytes_per_pixel: usize,
+    pub data: Vec<u8>,
+
+    // If we wanted these could be traits
+    // but we don't need that level of complexity
+    pub read_rgb_func: fn(&[u8]) -> Vec3,
+    pub write_rgb_func: fn(&mut [u8], Vec3),
+}
+
+impl PixelBuffer {
+    pub fn new(width: usize, height: usize, format: PixelFormat) -> Self {
+        let bytes_per_pixel = match format {
+            PixelFormat::SDR8bit | PixelFormat::HDR8bit => 3,
+            PixelFormat::HDRFloat16 => 8,
+            PixelFormat::HDRFloat32 => 16,
+        };
+        let read_rgb_func = match format {
+            PixelFormat::SDR8bit => read_srgb_rgb24,
+            PixelFormat::HDR8bit => read_rec2100_rgb24,
+            PixelFormat::HDRFloat16 => read_scrgb_rgb64half,
+            PixelFormat::HDRFloat32 => read_scrgb_rgb128float,
+        };
+        let write_rgb_func = match format {
+            PixelFormat::SDR8bit => write_srgb_rgb24,
+            PixelFormat::HDR8bit => write_rec2100_rgb24,
+            PixelFormat::HDRFloat16 => write_scrgb_rgb64half,
+            PixelFormat::HDRFloat32 => write_scrgb_rgb128float,
+        };
+        let stride = width * bytes_per_pixel;
+        let size = stride * height;
+        let data = vec![0u8; size];
+
+        PixelBuffer {
+            width,
+            height,
+            bytes_per_pixel,
+            data,
+            read_rgb_func,
+            write_rgb_func,
+        }
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub fn bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.data
+    }
+
+    pub fn par_iter(&self) -> impl IndexedParallelIterator<Item = &[u8]> {
+        self.data.par_chunks(self.bytes_per_pixel)
+    }
+
+    pub fn par_iter_mut(&mut self) -> impl IndexedParallelIterator<Item = &mut [u8]> {
+        self.data.par_chunks_mut(self.bytes_per_pixel)
+    }
+
+    pub fn pixels(&self) -> impl '_ + IndexedParallelIterator<Item = Vec3> {
+        self.par_iter().map(self.read_rgb_func)
+    }
+
+    pub fn fill<T>(&mut self, source: T)
+    where
+        T: IndexedParallelIterator<Item = Vec3>,
+    {
+        let write_rgb_func = self.write_rgb_func;
+        self.par_iter_mut()
+            .zip(source)
+            .for_each(|(dest, rgb)| write_rgb_func(dest, rgb))
+    }
+}

--- a/src/tonemap.rs
+++ b/src/tonemap.rs
@@ -1,0 +1,134 @@
+use glam::Vec3;
+use oklab::Oklab;
+
+use crate::{transforms::*, Context};
+
+/// Tonemap implementations
+#[derive(Copy, Clone, Debug, PartialEq, clap::ValueEnum)]
+pub enum Tonemap {
+    Linear,
+    Reinhard,
+    ReinhardRgb,
+    Aces,
+    Uncharted2,
+    Hable,
+}
+
+impl Tonemap {
+    /// Perform mapping for the [Tonemap] variant
+    pub fn map(&self, c_in: Vec3, options: &Context) -> Vec3 {
+        match self {
+            Tonemap::Linear => tonemap_linear(c_in, options),
+            Tonemap::Reinhard => tonemap_reinhard_oklab(c_in, options),
+            Tonemap::ReinhardRgb => tonemap_reinhard_rgb(c_in, options),
+            Tonemap::Aces => tonemap_aces(c_in, options),
+            Tonemap::Uncharted2 => tonemap_uncharted2(c_in, options),
+            Tonemap::Hable => tonemap_hable(c_in, options),
+        }
+    }
+}
+
+pub fn tonemap_linear(c_in: Vec3, _options: &Context) -> Vec3 {
+    c_in
+}
+
+/// Map luminance from HDR to SDR domain, and scale the input color
+/// in oklab perceptual color space.
+///
+/// oklab color space: https://bottosson.github.io/posts/oklab/
+pub fn tonemap_reinhard_oklab(c_in: Vec3, options: &Context) -> Vec3 {
+    //
+    let white = options.hdr_max;
+    let white2 = white * white;
+
+    // use Oklab's L coordinate as luminance
+    let oklab_in = scrgb_to_oklab(c_in);
+    let luma_in = luma_oklab(oklab_in);
+
+    // Reinhard tone-mapping algo.
+    //
+    // Original:
+    // http://www.cmap.polytechnique.fr/%7Epeyre/cours/x2005signal/hdr_photographic.pdf
+    //
+    // Extended:
+    // https://64.github.io/tonemapping/#reinhard
+    // TMO_reinhardext​(C) = C(1 + C/C_white^2​) / (1 + C)
+    //
+    let luma_out = luma_in * (1.0 + luma_in / white2) / (1.0 + luma_in);
+    let oklab_out = scale_oklab_desat(oklab_in, luma_out, options.saturation);
+    oklab_to_scrgb(oklab_out)
+}
+
+pub fn scale_oklab_desat(oklab_in: Oklab, luma_out: f32, saturation: f32) -> Oklab {
+    let l_in = oklab_in.l;
+    if l_in == 0.0 {
+        oklab_in
+    } else {
+        let l_out = oklab_l_for_luma(luma_out);
+        // oklab coords scale cubically
+        // 1.0 -> desaturate linearly according to luma compression ratio
+        // 0.5 -> desaturate more aggressively
+        // 2.0 -> saturate more aggressively
+        let ratio = (l_out / l_in).powf(3.0 / saturation);
+        Oklab {
+            l: l_out,
+            a: oklab_in.a * ratio,
+            b: oklab_in.b * ratio,
+        }
+    }
+}
+
+/// Variant that maps R, G, and B channels separately.
+/// This should desaturate very bright colors gradually, but will
+/// possible cause some color shift.
+pub fn tonemap_reinhard_rgb(c_in: Vec3, options: &Context) -> Vec3 {
+    let white = options.hdr_max;
+    let white2 = white * white;
+    c_in * (Vec3::ONE + c_in / white2) / (Vec3::ONE + c_in)
+}
+
+// https://64.github.io/tonemapping/#uncharted-2
+// Uncharted 2 / Hable Filmic
+pub fn uncharted2_tonemap_partial(x: f32) -> f32 {
+    const A: f32 = 0.15;
+    const B: f32 = 0.50;
+    const C: f32 = 0.10;
+    const D: f32 = 0.20;
+    const E: f32 = 0.02;
+    const F: f32 = 0.30;
+    ((x * (A * x + (C * B)) + (D * E)) / (x * (A * x + (B)) + (D * F))) - (E / F)
+}
+
+pub fn tonemap_uncharted2(v: Vec3, _options: &Context) -> Vec3 {
+    let exposure_bias: f32 = 2.0;
+    let luma = luma_rgb(v);
+    let curr = uncharted2_tonemap_partial(luma * exposure_bias);
+
+    let w = 11.2f32;
+    let white_scale = 1.0f32 / uncharted2_tonemap_partial(w);
+    let luma_out = curr * white_scale;
+
+    scale_rgb(v, luma_out)
+}
+
+pub fn tonemap_hable(val: Vec3, _options: &Context) -> Vec3 {
+    // stolen from ffmpeg's vf_tonemap
+
+    // desat
+    let luma = luma_rgb(val);
+    let desaturation: f32 = 2.0;
+    let epsilon: f32 = 1e-6;
+    let overbright = f32::max(luma - desaturation, epsilon) / f32::max(luma, epsilon);
+    let rgb_out = val * (1.0 - overbright) + luma * overbright;
+    let sig_orig = f32::max(rgb_out.max_element(), epsilon);
+
+    // hable/uncharted2
+    let exposure_bias: f32 = 2.0;
+    let luma = sig_orig;
+    let curr = uncharted2_tonemap_partial(luma * exposure_bias);
+    let w = 11.2f32;
+    let white_scale = 1.0f32 / uncharted2_tonemap_partial(w);
+    let sig = curr * white_scale;
+
+    rgb_out * (sig / sig_orig)
+}

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -1,0 +1,301 @@
+//! Image format reader and writers
+
+use std::cmp::Ordering;
+
+// Math bits
+use glam::{Mat3, Vec3};
+// 16-bit floats
+use half::prelude::*;
+use oklab::{linear_srgb_to_oklab, oklab_to_linear_srgb, Oklab};
+
+use crate::Context;
+
+pub fn read_srgb_rgb24(_data: &[u8]) -> Vec3 {
+    panic!("not yet implemented");
+}
+
+pub fn write_srgb_rgb24(data: &mut [u8], val: Vec3) {
+    let gamma_out = linear_to_srgb(val);
+    let clipped = clip(gamma_out);
+    let scaled = clipped * 255.0;
+    data[0] = scaled.x as u8;
+    data[1] = scaled.y as u8;
+    data[2] = scaled.z as u8;
+}
+
+pub fn read_rec2100_rgb24(data: &[u8]) -> Vec3 {
+    let scale = Vec3::splat(1.0 / 255.0);
+    let rgb_rec2100 = Vec3::new(data[0] as f32, data[1] as f32, data[2] as f32) * scale;
+    let rgb_linear = pq_to_linear(rgb_rec2100);
+    rec2100_to_scrgb(rgb_linear)
+}
+
+pub fn write_rec2100_rgb24(_data: &mut [u8], _rgb: Vec3) {
+    panic!("not yet implemented");
+}
+
+pub fn read_scrgb_rgb64half(data: &[u8]) -> Vec3 {
+    let data_ref_f16: &f16 = unsafe { std::mem::transmute(&data[0]) };
+    let data_f16 = unsafe { std::slice::from_raw_parts(data_ref_f16, data.len()) };
+    Vec3::new(
+        data_f16[0].to_f32(),
+        data_f16[1].to_f32(),
+        data_f16[2].to_f32(),
+    )
+}
+
+pub fn write_scrgb_rgb64half(data: &mut [u8], rgb: Vec3) {
+    let data_ref_f16: &mut f16 = unsafe { std::mem::transmute(&mut data[0]) };
+    let data_f16 = &mut unsafe { std::slice::from_raw_parts_mut(data_ref_f16, data.len()) };
+    data_f16[0] = f16::from_f32(rgb.x);
+    data_f16[1] = f16::from_f32(rgb.y);
+    data_f16[2] = f16::from_f32(rgb.z);
+}
+
+pub fn read_scrgb_rgb128float(data: &[u8]) -> Vec3 {
+    let data_ref_f32: &f32 = unsafe { std::mem::transmute(&data[0]) };
+    let data_f32 = unsafe { std::slice::from_raw_parts(data_ref_f32, data.len()) };
+    Vec3::new(data_f32[0], data_f32[1], data_f32[2])
+}
+
+pub fn write_scrgb_rgb128float(data: &mut [u8], rgb: Vec3) {
+    let data_ref_f32: &mut f32 = unsafe { std::mem::transmute(&mut data[0]) };
+    let data_f32 = &mut unsafe { std::slice::from_raw_parts_mut(data_ref_f32, data.len()) };
+    data_f32[0] = rgb.x;
+    data_f32[1] = rgb.y;
+    data_f32[2] = rgb.z;
+}
+
+pub fn pq_to_linear(val: Vec3) -> Vec3 {
+    // fixme make sure all the splats are efficient constants
+    let inv_m1: f32 = 1.0 / 0.15930176;
+    let inv_m2: f32 = 1.0 / 78.84375;
+    let c1 = Vec3::splat(0.8359375);
+    let c2 = Vec3::splat(18.851563);
+    let c3 = Vec3::splat(18.6875);
+    let val_powered = val.powf(inv_m2);
+    (Vec3::max(val_powered - c1, Vec3::ZERO) / (c2 - c3 * val_powered)).powf(inv_m1)
+}
+
+pub fn rec2100_to_scrgb(val: Vec3) -> Vec3 {
+    let matrix = Mat3::from_cols_array(&[
+        1.6605, -0.1246, -0.0182, -0.5876, 1.1329, -0.1006, -0.0728, -0.0083, 1.1187,
+    ]);
+    let scale = REC2100_MAX / SDR_WHITE;
+    matrix.mul_vec3(val * scale)
+}
+
+pub fn luma_scrgb(val: Vec3) -> f32 {
+    luma_oklab(scrgb_to_oklab(val))
+}
+
+pub fn luma_oklab(val: Oklab) -> f32 {
+    // oklab's l is not linear
+    // so translate it back to linear srgb desaturated
+    // and take one of its rgb values
+    let oklab_gray = Oklab {
+        l: val.l,
+        a: 0.0,
+        b: 0.0,
+    };
+    let rgb_gray = oklab_to_scrgb(oklab_gray);
+    rgb_gray.x
+}
+
+pub const EPSILON: f32 = 0.001; // good enough for us for now
+
+pub fn close_enough(a: f32, b: f32) -> Ordering {
+    let delta = a - b;
+    if delta.abs() < EPSILON {
+        Ordering::Equal
+    } else if delta < 0.0 {
+        Ordering::Less
+    } else {
+        Ordering::Greater
+    }
+}
+
+pub fn binary_search<I, O, F, G>(input: I, min: f32, max: f32, func: F, comparator: G) -> O
+where
+    I: Copy + Clone,
+    O: Copy + Clone,
+    F: Fn(I, f32) -> O,
+    G: Fn(O) -> Ordering,
+{
+    let mid = (min + max) / 2.0;
+    let result = func(input, mid);
+    match close_enough(min, max) {
+        Ordering::Equal => result,
+        _ => match comparator(result) {
+            Ordering::Less => binary_search(input, mid, max, func, comparator),
+            Ordering::Greater => binary_search(input, min, mid, func, comparator),
+            Ordering::Equal => result,
+        },
+    }
+}
+
+pub fn clip(input: Vec3) -> Vec3 {
+    input.max(Vec3::ZERO).min(Vec3::ONE)
+}
+
+pub fn darken_oklab(c_in: Oklab, brightness: f32) -> Vec3 {
+    let c_out = Oklab {
+        l: c_in.l * brightness,
+        a: c_in.a * brightness,
+        b: c_in.b * brightness,
+    };
+    oklab_to_scrgb(c_out)
+}
+
+pub fn desat_oklab(c_in: Oklab, saturation: f32) -> Vec3 {
+    let c_out = Oklab {
+        l: c_in.l,
+        a: c_in.a * saturation,
+        b: c_in.b * saturation,
+    };
+    oklab_to_scrgb(c_out)
+}
+
+pub fn luma_rgb(val: Vec3) -> f32 {
+    val.x * 0.2126 + val.y * 0.7152 + val.z * 0.0722
+}
+
+pub fn scale_rgb(val: Vec3, luma_out: f32) -> Vec3 {
+    let luma_in = luma_rgb(val);
+    let scale = luma_out / luma_in;
+    val * scale
+}
+
+// can't use glam's Mat3 as a constant literal?
+pub type Matrix3x3 = [[f32; 3]; 3];
+
+// https://64.github.io/tonemapping/#aces
+// ACES (Academy Color Encoding System)
+pub const ACES_INPUT_MATRIX: Matrix3x3 = [
+    [0.59719, 0.35458, 0.04823],
+    [0.07600, 0.90834, 0.01566],
+    [0.02840, 0.13383, 0.83777],
+];
+
+pub const ACES_OUTPUT_MATRIX: Matrix3x3 = [
+    [1.60475, -0.53108, -0.07367],
+    [-0.10208, 1.10813, -0.00605],
+    [-0.00327, -0.07276, 1.07602],
+];
+
+#[allow(clippy::many_single_char_names)]
+pub fn aces_mul(m: &Matrix3x3, v: Vec3) -> Vec3 {
+    let x = m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2];
+    let y = m[1][0] * v[1] + m[1][1] * v[1] + m[1][2] * v[2];
+    let z = m[2][0] * v[1] + m[2][1] * v[1] + m[2][2] * v[2];
+    Vec3::new(x, y, z)
+}
+
+pub fn aces_rtt_and_odt_fit(v: Vec3) -> Vec3 {
+    let a = v * (v + Vec3::splat(0.0245786)) - Vec3::splat(0.000090537);
+    let b = v * (Vec3::splat(0.983729) * v + Vec3::splat(0.432951)) + Vec3::splat(0.238081);
+    a / b
+}
+
+pub fn tonemap_aces(c_in: Vec3, _options: &Context) -> Vec3 {
+    let v = c_in;
+    let v = aces_mul(&ACES_INPUT_MATRIX, v);
+    let v = aces_rtt_and_odt_fit(v);
+    aces_mul(&ACES_OUTPUT_MATRIX, v)
+}
+
+/*
+pub fn srgb_to_linear(val: Vec3) -> Vec3 {
+    Vec3::select(
+        val.cmple(Vec3::splat(0.04045)),
+        val / Vec3::splat(12.92),
+        ((val + Vec3::splat(0.055)) / Vec3::splat(1.055)).powf(2.4)
+    )
+}
+*/
+
+pub fn linear_to_srgb(val: Vec3) -> Vec3 {
+    // fixme make sure all the splats are efficient constants
+    let min = Vec3::splat(0.0031308);
+    let linear = val * Vec3::splat(12.92);
+    let gamma = (val * Vec3::splat(1.055)).powf(1.0 / 2.4) - Vec3::splat(0.055);
+    Vec3::select(val.cmple(min), linear, gamma)
+}
+
+pub const REC2100_MAX: f32 = 10000.0; // the 1.0 value for BT.2100 linear
+pub const SDR_WHITE: f32 = 80.0;
+
+pub fn exposure_scale(stops: f32) -> f32 {
+    2.0_f32.powf(stops)
+}
+
+pub fn hdr_to_sdr_pixel(rgb_scrgb: Vec3, options: &Context) -> Vec3 {
+    let val = rgb_scrgb * options.scale;
+    let val = options.tone_map.map(val, options);
+    options.color_map.map(val)
+}
+
+pub fn scrgb_to_linear_srgb(c: Vec3) -> oklab::RGB<f32> {
+    oklab::RGB::new(c.x, c.y, c.z)
+}
+
+pub fn linear_srgb_to_scrgb(c: oklab::RGB<f32>) -> Vec3 {
+    Vec3::new(c.r, c.g, c.b)
+}
+
+pub fn oklab_l_for_luma(luma: f32) -> f32 {
+    let gray_rgb = oklab::RGB::new(luma, luma, luma);
+    let gray_oklab = linear_srgb_to_oklab(gray_rgb);
+    gray_oklab.l
+}
+
+pub fn scale_oklab_desat(oklab_in: Oklab, luma_out: f32, saturation: f32) -> Oklab {
+    let l_in = oklab_in.l;
+    if l_in == 0.0 {
+        oklab_in
+    } else {
+        let l_out = oklab_l_for_luma(luma_out);
+        // oklab coords scale cubically
+        // 1.0 -> desaturate linearly according to luma compression ratio
+        // 0.5 -> desaturate more aggressively
+        // 2.0 -> saturate more aggressively
+        let ratio = (l_out / l_in).powf(3.0 / saturation);
+        Oklab {
+            l: l_out,
+            a: oklab_in.a * ratio,
+            b: oklab_in.b * ratio,
+        }
+    }
+}
+
+pub fn scale_oklab(oklab_in: Oklab, luma_out: f32) -> Oklab {
+    if oklab_in.l == 0.0 {
+        oklab_in
+    } else {
+        let gray_l = oklab_l_for_luma(luma_out);
+        let ratio = gray_l / oklab_in.l;
+        Oklab {
+            l: gray_l,
+            a: oklab_in.a * ratio,
+            b: oklab_in.b * ratio,
+        }
+    }
+}
+
+pub fn scrgb_to_oklab(c: Vec3) -> Oklab {
+    linear_srgb_to_oklab(scrgb_to_linear_srgb(c))
+}
+
+pub fn oklab_to_scrgb(c: Oklab) -> Vec3 {
+    linear_srgb_to_scrgb(oklab_to_linear_srgb(c))
+}
+
+pub fn apply_levels(c_in: Vec3, level_min: f32, level_max: f32, gamma: f32) -> Vec3 {
+    let offset = level_min;
+    let scale = level_max - level_min;
+    let oklab_in = scrgb_to_oklab(c_in);
+    let luma_in = luma_oklab(oklab_in);
+    let luma_out = ((luma_in - offset) / scale).powf(gamma);
+    let oklab_out = scale_oklab(oklab_in, luma_out);
+    oklab_to_scrgb(oklab_out)
+}


### PR DESCRIPTION
hey thanks for making a neat thing! i wanted to try calling this as a library, so, had to do a bit of refactoring...

- first-pass moving things around to split the command line tool and library
- moves to enums for switchable functionality
- updates to a newer version of clap with derive to simplify all the argument parsing

i'm sure there are further improvements, at the moment all the internal functions are public and certainly not all in the best places, but this seemed like a good point to stop and open a PR and see if you're interested in the changes? ^_^